### PR TITLE
Fix dropdown menu on single-track albums

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -182,7 +182,7 @@
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   margin: 0 1rem 2rem 1rem; /* Added bottom margin */
-  overflow: hidden;
+  overflow: visible;
 }
 
 .track-item {

--- a/src/pages/Album.jsx
+++ b/src/pages/Album.jsx
@@ -221,11 +221,11 @@ const Album = () => {
       </div>
 
       {/* Track List */}
-      <div style={{ 
-        backgroundColor: 'white', 
-        borderRadius: '8px', 
+      <div style={{
+        backgroundColor: 'white',
+        borderRadius: '8px',
         boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
-        overflow: 'hidden'
+        overflow: 'visible'
       }}>
         {tracks.map((track, index) => (
           <Track 


### PR DESCRIPTION
Changed overflow from 'hidden' to 'visible' on track list containers to prevent the track action dropdown menu (play next, add to queue) from being clipped. This ensures the dropdown appears properly on top of the page content, especially for albums with only one track where the menu would extend below the container.

Modified:
- src/index.css: .track-list overflow changed to visible
- src/pages/Album.jsx: Track list container overflow changed to visible